### PR TITLE
Bot API 7.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 <a href="https://npmjs.com/package/telegram-webapps"><img alt="npm" src="https://img.shields.io/npm/dt/telegram-webapps"/></a>
 </p>
 <p align="center">
-<a href="https://core.telegram.org/bots/webapps"><img alt="Telegram Bot API Version 7.7" src="https://img.shields.io/badge/Telegram%20Bot%20API-7.7-blue.svg?logo=telegram"/></a>
+<a href="https://core.telegram.org/bots/webapps"><img alt="Telegram Bot API Version 7.8" src="https://img.shields.io/badge/Telegram%20Bot%20API-7.8-blue.svg?logo=telegram"/></a>
 </p>
 <p align="center">
 <a href="https://github.com/DavisDmitry/telegram-webapps/actions/workflows/lint.yml"><img alt="CI Lint" src="https://github.com/DavisDmitry/telegram-webapps/actions/workflows/lint.yml/badge.svg"/></a>
@@ -47,7 +47,7 @@ Include the types file inside your [ `tsconfig.json` ](https://www.typescriptlan
 ```diff
 {
   "compilerOptions": {
-    "typeRoots": [
+    "types": [
 +     "./node_modules/telegram-webapps"
     ]
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "telegram-webapps",
-  "version": "7.7.0",
+  "version": "7.8.0",
   "description": "Typings for Telegram Mini Apps",
   "keywords": [
     "telegram",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -446,6 +446,12 @@ export declare namespace TelegramWebApps {
      */
     openInvoice(url: string, callback?: InvoiceClosedEventHandler): void
     /**
+     * `Bot API 7.8+` A method that opens the native story editor with the media specified
+     * in the *media_url* parameter as an HTTPS URL. An optional *params* argument of the
+     * type StoryShareParams describes additional sharing settings.
+     */
+    shareToStory(media_url: string, params?: StoryShareParams): void
+    /**
      * `Bot API 6.2+` A method that shows a native popup described by the *params*
      * argument of the type PopupParams. The Web App will receive the event *popupClosed*
      * when the popup is closed. If an optional *callback* parameter was passed, the
@@ -640,6 +646,37 @@ export declare namespace TelegramWebApps {
      * Also available as the CSS variable `var(--tg-theme-destructive-text-color)`.
      */
     destructive_text_color?: string
+  }
+
+  /**
+   * This object describes additional sharing settings for the native story editor.
+   */
+  interface StoryShareParams {
+    /**
+     * The caption to be added to the media, 0-200 characters for regular users and 0-2048
+     * characters for premium subscribers.
+     */
+    text?: string
+    /**
+     * An object that describes a widget link to be included in the story. Note that only
+     * premium subscribers can post stories with links.
+     */
+    widget_link?: StoryWidgetLink
+  }
+
+  /**
+   * This object describes a widget link to be included in the story.
+   */
+
+  interface StoryWidgetLink {
+    /**
+     * The URL to be included in the story.
+     */
+    url: string
+    /**
+     * The name to be displayed for the widget link, 0-48 characters.
+     */
+    name?: string
   }
 
   /**


### PR DESCRIPTION
- Added the option for bots to set a [Main Mini App](https://core.telegram.org/bots/webapps#launching-the-main-mini-app), which can be previewed and launched directly from a button in the bot's profile or a link.
- Added the method shareToStory to the class [WebApp](https://core.telegram.org/bots/webapps#initializing-mini-apps).