### PR TITLE
Change custom_emoji_id Type to string in setEmojiStatus

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -973,7 +973,7 @@ export declare namespace TelegramWebApps {
      * via the Mini App method requestEmojiStatusAccess.*
      */
     setEmojiStatus(
-      custom_emoji_id: number,
+      custom_emoji_id: string,
       params?: EmojiStatusParams,
       callback?: (set: boolean) => void
     ): void


### PR DESCRIPTION
### 🛠 Fix: Change `custom_emoji_id` Type to string in [setEmojiStatus](https://github.com/DavisDmitry/telegram-webapps/blob/c0d984ed9922f34733734127255ab3f8a1911feb/src/index.d.ts#L975)

🎯 This pull request changes the type of `custom_emoji_id` in the [setEmojiStatus](https://github.com/DavisDmitry/telegram-webapps/blob/c0d984ed9922f34733734127255ab3f8a1911feb/src/index.d.ts#L975) method from **number to string** to handle large `custom_emoji_id` values without precision loss.

📚 The `custom_emoji_id` values, such as _5373141891321699086_, are too large to be accurately represented as JavaScript numbers due to the **64-bit floating-point representation**, which can lead to precision issues. **By changing the type to string**, we ensure that `custom_emoji_id` values are accurately passed to the `setEmojiStatus` method without losing precision.